### PR TITLE
use GCC 4.9.3 in intel/2016.00, stick to official tarball names, add HPL easyconfig for intel/2016.00

### DIFF
--- a/easybuild/easyconfigs/h/HPL/HPL-2.1-intel-2016.00.eb
+++ b/easybuild/easyconfigs/h/HPL/HPL-2.1-intel-2016.00.eb
@@ -1,0 +1,18 @@
+name = 'HPL'
+version = '2.1'
+
+homepage = 'http://www.netlib.org/benchmark/hpl/'
+description = """HPL is a software package that solves a (random) dense linear system in double precision (64 bits) arithmetic 
+ on distributed-memory computers. It can thus be regarded as a portable as well as freely available implementation of the 
+ High Performance Computing Linpack Benchmark."""
+
+toolchain = {'name': 'intel', 'version': '2016.00'}
+toolchainopts = {'optarch': True, 'usempi': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.netlib.org/benchmark/%(namelower)s']
+
+# fix Make dependencies, so parallel build also works
+patches = ['HPL_parallel-make.patch']
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/i/icc/icc-2016.0.109-GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.0.109-GCC-4.9.3.eb
@@ -8,12 +8,12 @@ description = "C and C++ compiler from Intel"
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp_%(version)s.tgz']
+sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp.tgz']
 
 checksums = ['f57a892fb494db3c80f20a88aa3e901f']
 
 gcc = 'GCC'
-gccver = '5.2.0'
+gccver = '4.9.3'
 versionsuffix = '-%s-%s' % (gcc, gccver)
 
 dependencies = [(gcc, gccver)]

--- a/easybuild/easyconfigs/i/icc/icc-2016.0.109-GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.0.109-GCC-4.9.3.eb
@@ -18,6 +18,8 @@ versionsuffix = '-%s-%s' % (gcc, gccver)
 
 dependencies = [(gcc, gccver)]
 
+components = ['intel-comp.*', 'intel-ccomp.*', 'intel-icc-.*', 'intel-openmp.*', 'intel-ipsc?.*']
+
 dontcreateinstalldir = 'True'
 
 # license file

--- a/easybuild/easyconfigs/i/icc/icc-2016.0.109-GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.0.109-GCC-4.9.3.eb
@@ -20,7 +20,7 @@ dependencies = [(gcc, gccver)]
 
 # full list of components can be obtained from pset/mediaconfig.xml in unpacked sources
 # cfr. https://software.intel.com/en-us/articles/intel-composer-xe-2015-silent-installation-guide
-components = ['intel-comp.*', 'intel-ccomp.*', 'intel-icc-.*', 'intel-openmp.*', 'intel-ipsc?.*']
+components = ['intel-comp', 'intel-ccomp', 'intel-icc', 'intel-openmp', 'intel-ipsc?']
 
 dontcreateinstalldir = 'True'
 

--- a/easybuild/easyconfigs/i/icc/icc-2016.0.109-GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.0.109-GCC-4.9.3.eb
@@ -18,6 +18,8 @@ versionsuffix = '-%s-%s' % (gcc, gccver)
 
 dependencies = [(gcc, gccver)]
 
+# full list of components can be obtained from pset/mediaconfig.xml in unpacked sources
+# cfr. https://software.intel.com/en-us/articles/intel-composer-xe-2015-silent-installation-guide
 components = ['intel-comp.*', 'intel-ccomp.*', 'intel-icc-.*', 'intel-openmp.*', 'intel-ipsc?.*']
 
 dontcreateinstalldir = 'True'

--- a/easybuild/easyconfigs/i/icc/icc-2016.0.109-GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.0.109-GCC-4.9.3.eb
@@ -20,7 +20,7 @@ dependencies = [(gcc, gccver)]
 
 # full list of components can be obtained from pset/mediaconfig.xml in unpacked sources
 # cfr. https://software.intel.com/en-us/articles/intel-composer-xe-2015-silent-installation-guide
-components = ['intel-comp', 'intel-ccomp', 'intel-icc', 'intel-openmp', 'intel-ipsc?']
+components = ['intel-comp', 'intel-ccomp', 'intel-icc', 'intel-openmp', 'intel-ipsc?_']
 
 dontcreateinstalldir = 'True'
 

--- a/easybuild/easyconfigs/i/icc/icc-2016.0.109.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.0.109.eb
@@ -12,6 +12,8 @@ sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp.tgz']
 
 checksums = ['f57a892fb494db3c80f20a88aa3e901f']
 
+components = ['intel-comp.*', 'intel-ccomp.*', 'intel-icc-.*', 'intel-openmp.*', 'intel-ipsc?.*']
+
 dontcreateinstalldir = 'True'
 
 # license file

--- a/easybuild/easyconfigs/i/icc/icc-2016.0.109.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.0.109.eb
@@ -8,7 +8,7 @@ description = "C and C++ compiler from Intel"
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp_%(version)s.tgz']
+sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp.tgz']
 
 checksums = ['f57a892fb494db3c80f20a88aa3e901f']
 

--- a/easybuild/easyconfigs/i/icc/icc-2016.0.109.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.0.109.eb
@@ -12,6 +12,8 @@ sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp.tgz']
 
 checksums = ['f57a892fb494db3c80f20a88aa3e901f']
 
+# full list of components can be obtained from pset/mediaconfig.xml in unpacked sources
+# cfr. https://software.intel.com/en-us/articles/intel-composer-xe-2015-silent-installation-guide
 components = ['intel-comp.*', 'intel-ccomp.*', 'intel-icc-.*', 'intel-openmp.*', 'intel-ipsc?.*']
 
 dontcreateinstalldir = 'True'

--- a/easybuild/easyconfigs/i/icc/icc-2016.0.109.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.0.109.eb
@@ -14,7 +14,7 @@ checksums = ['f57a892fb494db3c80f20a88aa3e901f']
 
 # full list of components can be obtained from pset/mediaconfig.xml in unpacked sources
 # cfr. https://software.intel.com/en-us/articles/intel-composer-xe-2015-silent-installation-guide
-components = ['intel-comp.*', 'intel-ccomp.*', 'intel-icc-.*', 'intel-openmp.*', 'intel-ipsc?.*']
+components = ['intel-comp', 'intel-ccomp', 'intel-icc', 'intel-openmp', 'intel-ipsc?']
 
 dontcreateinstalldir = 'True'
 

--- a/easybuild/easyconfigs/i/icc/icc-2016.0.109.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.0.109.eb
@@ -14,7 +14,7 @@ checksums = ['f57a892fb494db3c80f20a88aa3e901f']
 
 # full list of components can be obtained from pset/mediaconfig.xml in unpacked sources
 # cfr. https://software.intel.com/en-us/articles/intel-composer-xe-2015-silent-installation-guide
-components = ['intel-comp', 'intel-ccomp', 'intel-icc', 'intel-openmp', 'intel-ipsc?']
+components = ['intel-comp', 'intel-ccomp', 'intel-icc', 'intel-openmp', 'intel-ipsc?_']
 
 dontcreateinstalldir = 'True'
 

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2016.0.109-GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2016.0.109-GCC-4.9.3.eb
@@ -10,7 +10,7 @@ description = """Intel Cluster Toolkit Compiler Edition provides Intel C,C++ and
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 gcc = 'GCC'
-gccver = '5.2.0'
+gccver = '4.9.3'
 versionsuffix = '-%s-%s' % (gcc, gccver)
 
 dependencies = [

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.0.109-GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.0.109-GCC-4.9.3.eb
@@ -8,12 +8,12 @@ description = "C and C++ compiler from Intel"
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_fortran_%(version)s.tgz']
+sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_fortran.tgz']
 
 checksums = ['bce7f6a71f7e44f67956197501d00b7c']
 
 gcc = 'GCC'
-gccver = '5.2.0'
+gccver = '4.9.3'
 versionsuffix = "-%s-%s" % ( gcc, gccver )
 
 dependencies = [(gcc, gccver)]

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.0.109-GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.0.109-GCC-4.9.3.eb
@@ -18,6 +18,8 @@ versionsuffix = "-%s-%s" % ( gcc, gccver )
 
 dependencies = [(gcc, gccver)]
 
+components = ['intel-comp.*', 'intel-fcomp.*', 'intel-ifort-.*', 'intel-openmp.*', 'intel-ipsf?.*']
+
 dontcreateinstalldir = 'True'
 
 # license file

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.0.109-GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.0.109-GCC-4.9.3.eb
@@ -20,7 +20,7 @@ dependencies = [(gcc, gccver)]
 
 # full list of components can be obtained from pset/mediaconfig.xml in unpacked sources
 # cfr. https://software.intel.com/en-us/articles/intel-composer-xe-2015-silent-installation-guide
-components = ['intel-comp.*', 'intel-fcomp.*', 'intel-ifort-.*', 'intel-openmp.*', 'intel-ipsf?.*']
+components = ['intel-comp', 'intel-fcomp', 'intel-ifort', 'intel-openmp', 'intel-ipsf?']
 
 dontcreateinstalldir = 'True'
 

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.0.109-GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.0.109-GCC-4.9.3.eb
@@ -18,6 +18,8 @@ versionsuffix = "-%s-%s" % ( gcc, gccver )
 
 dependencies = [(gcc, gccver)]
 
+# full list of components can be obtained from pset/mediaconfig.xml in unpacked sources
+# cfr. https://software.intel.com/en-us/articles/intel-composer-xe-2015-silent-installation-guide
 components = ['intel-comp.*', 'intel-fcomp.*', 'intel-ifort-.*', 'intel-openmp.*', 'intel-ipsf?.*']
 
 dontcreateinstalldir = 'True'

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.0.109-GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.0.109-GCC-4.9.3.eb
@@ -20,7 +20,7 @@ dependencies = [(gcc, gccver)]
 
 # full list of components can be obtained from pset/mediaconfig.xml in unpacked sources
 # cfr. https://software.intel.com/en-us/articles/intel-composer-xe-2015-silent-installation-guide
-components = ['intel-comp', 'intel-fcomp', 'intel-ifort', 'intel-openmp', 'intel-ipsf?']
+components = ['intel-comp', 'intel-fcomp', 'intel-ifort', 'intel-openmp', 'intel-ipsf?_']
 
 dontcreateinstalldir = 'True'
 

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.0.109.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.0.109.eb
@@ -8,7 +8,7 @@ description = "C and C++ compiler from Intel"
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_fortran_%(version)s.tgz']
+sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_fortran.tgz']
 
 checksums = ['bce7f6a71f7e44f67956197501d00b7c']
 

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.0.109.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.0.109.eb
@@ -12,6 +12,8 @@ sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_fortran.tg
 
 checksums = ['bce7f6a71f7e44f67956197501d00b7c']
 
+components = ['intel-comp.*', 'intel-fcomp.*', 'intel-ifort-.*', 'intel-openmp.*', 'intel-ipsf?.*']
+
 dontcreateinstalldir = 'True'
 
 # license file

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.0.109.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.0.109.eb
@@ -14,7 +14,7 @@ checksums = ['bce7f6a71f7e44f67956197501d00b7c']
 
 # full list of components can be obtained from pset/mediaconfig.xml in unpacked sources
 # cfr. https://software.intel.com/en-us/articles/intel-composer-xe-2015-silent-installation-guide
-components = ['intel-comp.*', 'intel-fcomp.*', 'intel-ifort-.*', 'intel-openmp.*', 'intel-ipsf?.*']
+components = ['intel-comp', 'intel-fcomp', 'intel-ifort', 'intel-openmp', 'intel-ipsf?']
 
 dontcreateinstalldir = 'True'
 

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.0.109.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.0.109.eb
@@ -14,7 +14,7 @@ checksums = ['bce7f6a71f7e44f67956197501d00b7c']
 
 # full list of components can be obtained from pset/mediaconfig.xml in unpacked sources
 # cfr. https://software.intel.com/en-us/articles/intel-composer-xe-2015-silent-installation-guide
-components = ['intel-comp', 'intel-fcomp', 'intel-ifort', 'intel-openmp', 'intel-ipsf?']
+components = ['intel-comp', 'intel-fcomp', 'intel-ifort', 'intel-openmp', 'intel-ipsf?_']
 
 dontcreateinstalldir = 'True'
 

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.0.109.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.0.109.eb
@@ -12,6 +12,8 @@ sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_fortran.tg
 
 checksums = ['bce7f6a71f7e44f67956197501d00b7c']
 
+# full list of components can be obtained from pset/mediaconfig.xml in unpacked sources
+# cfr. https://software.intel.com/en-us/articles/intel-composer-xe-2015-silent-installation-guide
 components = ['intel-comp.*', 'intel-fcomp.*', 'intel-ifort-.*', 'intel-openmp.*', 'intel-ipsf?.*']
 
 dontcreateinstalldir = 'True'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2016.00-GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2016.00-GCC-4.9.3.eb
@@ -3,16 +3,14 @@ easyblock = "Toolchain"
 
 name = 'iimpi'
 version = '2016.00'
-versionsuffix = '-GCC-5.2.0'
+versionsuffix = '-GCC-4.9.3'
 
 homepage = 'http://software.intel.com/en-us/intel-cluster-toolkit-compiler/'
 description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-suff = '0.109'
-compver = '2016.%s' % suff
-
+compver = '2016.0.109'
 dependencies = [
     ('icc', compver, versionsuffix),
     ('ifort', compver, versionsuffix),

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.0.109-iimpi-2016.00-GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.0.109-iimpi-2016.00-GCC-4.9.3.eb
@@ -9,7 +9,7 @@ description = """Intel Math Kernel Library is a library of highly optimized,
  applications that require maximum performance. Core math functions include
  BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
 
-toolchain = {'name': 'iimpi', 'version': '2016.00-GCC-5.2.0'}
+toolchain = {'name': 'iimpi', 'version': '2016.00-GCC-4.9.3'}
 
 sources = ['l_mkl_%(version)s.tgz']
 checksums = ['47567e38801efe273b36b5250c759af7']

--- a/easybuild/easyconfigs/i/impi/impi-5.1.1.109-iccifort-2016.0.109-GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/i/impi/impi-5.1.1.109-iccifort-2016.0.109-GCC-4.9.3.eb
@@ -8,7 +8,7 @@ description = """The Intel(R) MPI Library for Linux* OS is a multi-fabric messag
  passing library based on ANL MPICH2 and OSU MVAPICH2. The Intel MPI Library for
  Linux OS implements the Message Passing Interface, version 2 (MPI-2) specification."""
 
-toolchain = {'name': 'iccifort', 'version': '2016.0.109-GCC-5.2.0'}
+toolchain = {'name': 'iccifort', 'version': '2016.0.109-GCC-4.9.3'}
 
 sources = ['l_mpi_p_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/intel/intel-2016.00.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2016.00.eb
@@ -10,7 +10,7 @@ description = """Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 compver = '2016.0.109'
-gccsuff = '-GCC-5.2.0'
+gccsuff = '-GCC-4.9.3'
 
 dependencies = [
     ('icc', compver, gccsuff),


### PR DESCRIPTION
using GCC 5.x is not an option yet with this version of the Intel compilers, see also https://github.com/hpcugent/easybuild-easyconfigs/issues/2100

@DirkdeDraak: please merge to update https://github.com/hpcugent/easybuild-easyconfigs/pull/1973 and make it eligible for merge 

The plan is to include it in EasyBuild v2.5.0, as soon as https://github.com/hpcugent/easybuild-easyblocks/pull/756, which wraps around your easyblock PR https://github.com/hpcugent/easybuild-easyblocks/pull/691 gets merged.

See also https://github.com/hpcugent/easybuild/wiki/Conference-call-notes-20151203.

cc @wpoely86, @jas02